### PR TITLE
Notegram 🛫 🛫 🛫 Despegando version v6.0.1 🛫 🛫 🛫

### DIFF
--- a/proyectos.md
+++ b/proyectos.md
@@ -8,7 +8,7 @@ Cambiad la versión si no es esa la que tenéis en vuestro tag.
 | [CryptoGo](https://github.com/CriptoInfo/CryptoGo)                      | v7.0.0  |
 | [Gortana](https://github.com/Pibes-GRX/Gortana)                         | v10.0.0 |
 | [El tiempo](https://github.com/tddgrupo4/TDD-Grupo-4)                   | v3.0.0  |
-| [NoteGram](https://github.com/NoteGramBot/NoteGram)                     | v5.0.0  |
+| [NoteGram](https://github.com/NoteGramBot/NoteGram)                     | v6.0.1  |
 | [Palabrot](https://github.com/ScalaBot-Team/PalaBrot)                   | v11.0.2 |
 | [BoTTutorias](https://github.com/BoTTuros/BoTTutorias)                  | v7.0.1  |
 |    [Zero, the bellhop.](https://github.com/monium/zero)                 | v5.0.0  |


### PR DESCRIPTION
A ver que tal se porta la v6.0.1 de Notegram.
Hemos hecho una cosa raruna y es que cada uno de los 3 ficheros .go tienen su propia excepcion para no pisarnos (mucho).