### PR TITLE
Notegram v11 🚀🚀🚀🚀

### DIFF
--- a/proyectos.md
+++ b/proyectos.md
@@ -8,7 +8,7 @@ Cambiad la versión si no es esa la que tenéis en vuestro tag.
 | [CryptoGo](https://github.com/CriptoInfo/CryptoGo)                      | v10.0.1  |
 | [Gortana](https://github.com/Pibes-GRX/Gortana)                         | v10.0.0 |
 | [El tiempo](https://github.com/tddgrupo4/TDD-Grupo-4)                   | v3.0.0  |
-| [NoteGram](https://github.com/NoteGramBot/NoteGram)                     | v11.0.0  |
+| [NoteGram](https://github.com/NoteGramBot/NoteGram)                     | v11.0.1  |
 | [Palabrot](https://github.com/ScalaBot-Team/PalaBrot)                   | v13.0.2 |
 | [BoTTutorias](https://github.com/BoTTuros/BoTTutorias)                  | v7.0.1  |
 |    [Zero, the bellhop.](https://github.com/monium/zero)                 | v5.0.0  |

--- a/proyectos.md
+++ b/proyectos.md
@@ -8,7 +8,7 @@ Cambiad la versión si no es esa la que tenéis en vuestro tag.
 | [CryptoGo](https://github.com/CriptoInfo/CryptoGo)                      | v10.0.1  |
 | [Gortana](https://github.com/Pibes-GRX/Gortana)                         | v10.0.0 |
 | [El tiempo](https://github.com/tddgrupo4/TDD-Grupo-4)                   | v3.0.0  |
-| [NoteGram](https://github.com/NoteGramBot/NoteGram)                     | v10.0.1  |
+| [NoteGram](https://github.com/NoteGramBot/NoteGram)                     | v11.0.0  |
 | [Palabrot](https://github.com/ScalaBot-Team/PalaBrot)                   | v13.0.2 |
 | [BoTTutorias](https://github.com/BoTTuros/BoTTutorias)                  | v7.0.1  |
 |    [Zero, the bellhop.](https://github.com/monium/zero)                 | v5.0.0  |


### PR DESCRIPTION
V11 - Esta version tiene bastante trabajo "por detrás" del que no se ve:


- El código se ha movido de /src a / para cumplir con la forma de trabajar en GO (https://golang.org/doc/code
-  maskfile.md -> nueva opción mask yaml para leer los ficheros yaml antes de subirlos al repo y no volvernos locos.
- Integración con Travis:
    - Descarga Mask desde gitgub y lo instala en el equipo de Travis.
    - Hace limpieza de ficheros de la fase before_install para no llenar de 💩💩 el runner de Travis.
    - Ejecuta `mask depend` y `mask test` para cargar dependencias y pasar los tests respectivamente.
    - Banner de Travis en el readme
    - Resultado de test de travis se puede ver en: https://travis-ci.com/github/NoteGramBot/NoteGram
- "Grading del código GO en el Readme. Tenemos una "B" (no está mal para empezar con go).

